### PR TITLE
chore: denoise renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,34 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    "group:allNonMajor"
+  ],
+  "labels": ["maintenance"],
+  "packageRules": [
+    {
+      "packagePatterns": [ "jest", "sinon", "codecov", "lint", "jsdoc", "bundle", "prettier", "webpack", "typescript" ],
+      "groupName": "builders-and-testers",
+      "automerge": true,
+      "automergeType": "branch",
+      "schedule": ["before 5am"]
+    },
+    {
+      "packagePatterns": [ "semantic", "commitlint" ],
+      "groupName": "automation",
+      "automerge": true,
+      "automergeType": "branch",
+      "schedule": ["before 5am"]
+    },
+    {
+      "depTypeList": ["devDependencies"],
+      "groupName": "devDeps",
+      "automerge": true,
+      "automergeType": "branch",
+      "schedule": ["before 5am"]
+    },
+    {
+      "updateTypes": ["minor", "patch"],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
with this changeset, we should be seeing fewer notifications from renovate bot, while still keeping the relevant automation active